### PR TITLE
【Next.js】新規登録ページの作成

### DIFF
--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { SignUp } from '@/features/SignUp';
+
+const SignUpPage = (): React.JSX.Element => <SignUp />;
+
+export default SignUpPage;

--- a/frontend/components/Header/index.tsx
+++ b/frontend/components/Header/index.tsx
@@ -53,7 +53,7 @@ export const Header = (): React.JSX.Element => {
                 <Button LinkComponent={Link} color="inherit" variant="outlined" href="/login">
                   ログイン
                 </Button>
-                <Button LinkComponent={Link} color="inherit" variant="outlined">
+                <Button LinkComponent={Link} color="inherit" variant="outlined" href="/signup">
                   新規登録
                 </Button>
               </Box>

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { loginAuth } from '@/libs/services/auth';
+import { loginAuth, signUpAuth } from '@/libs/services/auth';
 import { createContext, useContext, useState, ReactNode, useEffect } from 'react';
 
 type User = {
@@ -13,6 +13,17 @@ type AuthContextType = {
   user: User | null;
   login: ({ email, password }: { email: string; password: string }) => Promise<void>;
   logout: () => void;
+  signUp: ({
+    email,
+    password,
+    password_confirmation,
+    name,
+  }: {
+    email: string;
+    password: string;
+    password_confirmation: string;
+    name: string;
+  }) => Promise<void>;
 };
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -43,7 +54,26 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   const logout = () => setUser(null);
 
-  return <AuthContext.Provider value={{ user, login, logout }}>{children}</AuthContext.Provider>;
+  const signUp = async ({
+    email,
+    password,
+    password_confirmation,
+    name,
+  }: {
+    email: string;
+    password: string;
+    password_confirmation: string;
+    name: string;
+  }) => {
+    const { token, user } = await signUpAuth({ email, password, password_confirmation, name });
+    localStorage.setItem('token', token);
+    localStorage.setItem('user', JSON.stringify(user));
+    setUser(user);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout, signUp }}>{children}</AuthContext.Provider>
+  );
 };
 
 export const useAuth = (): AuthContextType => {

--- a/frontend/features/Login/index.tsx
+++ b/frontend/features/Login/index.tsx
@@ -41,7 +41,11 @@ export const Login = (): React.JSX.Element => {
 
   return (
     <Box sx={{ padding: 2, maxWidth: '960px', width: '100%', margin: '0 auto' }}>
-      <Typography variant="h4" component="p" textAlign="center" sx={{ fontWeight: 'bold', mt: 4 }}>
+      <Typography
+        variant="h4"
+        component="p"
+        sx={{ fontWeight: 'bold', mt: 4, textAlign: 'center' }}
+      >
         ログイン
       </Typography>
 

--- a/frontend/features/SignUp/index.tsx
+++ b/frontend/features/SignUp/index.tsx
@@ -45,7 +45,11 @@ export const SignUp = (): React.JSX.Element => {
 
   return (
     <Box sx={{ padding: 2, maxWidth: '960px', width: '100%', margin: '0 auto' }}>
-      <Typography variant="h4" component="p" textAlign="center" sx={{ fontWeight: 'bold', mt: 4 }}>
+      <Typography
+        variant="h4"
+        component="p"
+        sx={{ fontWeight: 'bold', mt: 4, textAlign: 'center' }}
+      >
         新規登録
       </Typography>
       {errorMessage && (

--- a/frontend/features/SignUp/index.tsx
+++ b/frontend/features/SignUp/index.tsx
@@ -1,0 +1,128 @@
+import { Alert, Button, Typography } from '@mui/material';
+import { Box, TextField } from '@mui/material';
+import { useForm, SubmitHandler } from 'react-hook-form';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/context/AuthContext';
+import { useState } from 'react';
+
+type SignUpForm = {
+  email: string;
+  password: string;
+  password_confirmation: string;
+};
+
+export const SignUp = (): React.JSX.Element => {
+  const [errorMessage, setErrorMessage] = useState<string>('');
+  const router = useRouter();
+  const { signUp } = useAuth();
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<SignUpForm>();
+
+  const password = watch('password');
+
+  const onSubmit: SubmitHandler<SignUpForm> = async (data: SignUpForm) => {
+    const { email, password, password_confirmation } = data;
+    const name = email.split('@')[0];
+    try {
+      await signUp({ email, password, password_confirmation, name });
+      router.push('/mypage');
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : typeof error === 'string'
+            ? error
+            : '不明なエラーが発生しました';
+
+      setErrorMessage(message);
+    }
+  };
+
+  return (
+    <Box sx={{ padding: 2, maxWidth: '960px', width: '100%', margin: '0 auto' }}>
+      <Typography variant="h4" component="p" textAlign="center" sx={{ fontWeight: 'bold', mt: 4 }}>
+        新規登録
+      </Typography>
+      {errorMessage && (
+        <Alert severity="error" sx={{ mt: 2 }}>
+          {errorMessage}
+        </Alert>
+      )}
+      <Box sx={{ padding: 2, width: '100%' }}>
+        <Box
+          component="form"
+          sx={{ width: '100%', maxWidth: 600, mx: 'auto', mt: 5 }}
+          onSubmit={handleSubmit(onSubmit)}
+        >
+          <Box sx={{ mb: 2 }}>
+            <Typography>メールアドレス</Typography>
+            <TextField
+              fullWidth
+              variant="outlined"
+              {...register('email', {
+                required: 'メールアドレスを入力してください',
+                pattern: {
+                  value: /^[\w.-]+@[\w.-]+\.[A-Za-z]{2,}$/,
+                  message: 'メールアドレスの形式が正しくありません',
+                },
+              })}
+              error={!!errors.email}
+              helperText={errors.email?.message}
+            />
+          </Box>
+          <Box sx={{ mb: 2 }}>
+            <Typography>パスワード</Typography>
+            <TextField
+              type="password"
+              fullWidth
+              variant="outlined"
+              {...register('password', {
+                required: 'パスワードを入力してください',
+                minLength: { value: 8, message: '8文字以上で入力してください' },
+              })}
+              error={!!errors.password}
+              helperText={errors.password?.message}
+            />
+          </Box>
+          <Box sx={{ mb: 2 }}>
+            <Typography>パスワード(再入力)</Typography>
+            <TextField
+              type="password"
+              fullWidth
+              variant="outlined"
+              {...register('password_confirmation', {
+                required: 'パスワードを入力してください',
+                minLength: { value: 8, message: '8文字以上で入力してください' },
+                validate: value => value === password || '入力されたパスワードと一致しません',
+              })}
+              error={!!errors.password_confirmation}
+              helperText={errors.password_confirmation?.message}
+            />
+          </Box>
+          <Box sx={{ my: 4 }}>
+            <Button
+              type="submit"
+              sx={{
+                width: '100%',
+                backgroundColor: '#000000',
+                color: '#ffffff',
+                p: 2,
+                fontSize: 'large',
+              }}
+            >
+              新規登録
+            </Button>
+          </Box>
+          <Box sx={{ width: '100%', textAlign: 'center' }}>
+            <Link href="/login">すでにアカウントをお持ちの方はこちら</Link>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+};

--- a/frontend/libs/services/auth.ts
+++ b/frontend/libs/services/auth.ts
@@ -47,3 +47,48 @@ export const loginAuth = async ({
     throw error;
   }
 };
+
+export const signUpAuth = async ({
+  email,
+  password,
+  password_confirmation,
+  name,
+}: {
+  email: string;
+  password: string;
+  password_confirmation: string;
+  name: string;
+}): Promise<{ token: string; user: { id: number; name: string; email: string } }> => {
+  const url = 'http://localhost:5000/api/v1/user';
+  try {
+    const headers = {
+      'Content-Type': 'application/json',
+    };
+    const data = {
+      user: {
+        email,
+        password,
+        password_confirmation,
+        name,
+      },
+    };
+
+    const response = await axios.post(url, data, { headers });
+
+    const token = response.headers.authorization.split(' ')[1];
+    if (!token) throw new Error('トークンがありません');
+
+    return { token, user: response.data.user };
+  } catch (error) {
+    console.error(error);
+    if (axios.isAxiosError(error) && error.response) {
+      const data = error.response.data as unknown;
+      if (typeof data === 'object' && data !== null && 'message' in data) {
+        const { message } = data as ErrorResponseData;
+        throw new Error(message ?? '新規作成に失敗しました');
+      }
+      throw new Error('新規作成に失敗しました');
+    }
+    throw error;
+  }
+};

--- a/frontend/scripts/ApiTypeGenerator.ts
+++ b/frontend/scripts/ApiTypeGenerator.ts
@@ -4,7 +4,7 @@ async function main() {
   try {
     await generateApi({
       url: 'http://localhost:5000/api-docs/v1/swagger.yaml',
-      output: './src/types/generated',
+      output: './types/generated',
       fileName: 'Api.ts',
     });
     console.log('API生成成功');

--- a/frontend/src/types/generated/Api.ts
+++ b/frontend/src/types/generated/Api.ts
@@ -283,6 +283,8 @@ export class Api<
         password: string;
         /** @example "password123" */
         password_confirmation: string;
+        /** @example "test" */
+        name: string;
       },
       params: RequestParams = {},
     ) =>

--- a/frontend/src/types/generated/Api.ts
+++ b/frontend/src/types/generated/Api.ts
@@ -1,0 +1,317 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export type QueryParamsType = Record<string | number, any>;
+export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
+
+export interface FullRequestParams extends Omit<RequestInit, "body"> {
+  /** set parameter to `true` for call `securityWorker` for this request */
+  secure?: boolean;
+  /** request path */
+  path: string;
+  /** content type of request body */
+  type?: ContentType;
+  /** query params */
+  query?: QueryParamsType;
+  /** format of response (i.e. response.json() -> format: "json") */
+  format?: ResponseFormat;
+  /** request body */
+  body?: unknown;
+  /** base url */
+  baseUrl?: string;
+  /** request cancellation token */
+  cancelToken?: CancelToken;
+}
+
+export type RequestParams = Omit<
+  FullRequestParams,
+  "body" | "method" | "query" | "path"
+>;
+
+export interface ApiConfig<SecurityDataType = unknown> {
+  baseUrl?: string;
+  baseApiParams?: Omit<RequestParams, "baseUrl" | "cancelToken" | "signal">;
+  securityWorker?: (
+    securityData: SecurityDataType | null,
+  ) => Promise<RequestParams | void> | RequestParams | void;
+  customFetch?: typeof fetch;
+}
+
+export interface HttpResponse<D extends unknown, E extends unknown = unknown>
+  extends Response {
+  data: D;
+  error: E;
+}
+
+type CancelToken = Symbol | string | number;
+
+export enum ContentType {
+  Json = "application/json",
+  JsonApi = "application/vnd.api+json",
+  FormData = "multipart/form-data",
+  UrlEncoded = "application/x-www-form-urlencoded",
+  Text = "text/plain",
+}
+
+export class HttpClient<SecurityDataType = unknown> {
+  public baseUrl: string = "";
+  private securityData: SecurityDataType | null = null;
+  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
+  private abortControllers = new Map<CancelToken, AbortController>();
+  private customFetch = (...fetchParams: Parameters<typeof fetch>) =>
+    fetch(...fetchParams);
+
+  private baseApiParams: RequestParams = {
+    credentials: "same-origin",
+    headers: {},
+    redirect: "follow",
+    referrerPolicy: "no-referrer",
+  };
+
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
+  }
+
+  public setSecurityData = (data: SecurityDataType | null) => {
+    this.securityData = data;
+  };
+
+  protected encodeQueryParam(key: string, value: any) {
+    const encodedKey = encodeURIComponent(key);
+    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+  }
+
+  protected addQueryParam(query: QueryParamsType, key: string) {
+    return this.encodeQueryParam(key, query[key]);
+  }
+
+  protected addArrayQueryParam(query: QueryParamsType, key: string) {
+    const value = query[key];
+    return value.map((v: any) => this.encodeQueryParam(key, v)).join("&");
+  }
+
+  protected toQueryString(rawQuery?: QueryParamsType): string {
+    const query = rawQuery || {};
+    const keys = Object.keys(query).filter(
+      (key) => "undefined" !== typeof query[key],
+    );
+    return keys
+      .map((key) =>
+        Array.isArray(query[key])
+          ? this.addArrayQueryParam(query, key)
+          : this.addQueryParam(query, key),
+      )
+      .join("&");
+  }
+
+  protected addQueryParams(rawQuery?: QueryParamsType): string {
+    const queryString = this.toQueryString(rawQuery);
+    return queryString ? `?${queryString}` : "";
+  }
+
+  private contentFormatters: Record<ContentType, (input: any) => any> = {
+    [ContentType.Json]: (input: any) =>
+      input !== null && (typeof input === "object" || typeof input === "string")
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.JsonApi]: (input: any) =>
+      input !== null && (typeof input === "object" || typeof input === "string")
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.Text]: (input: any) =>
+      input !== null && typeof input !== "string"
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.FormData]: (input: any) =>
+      Object.keys(input || {}).reduce((formData, key) => {
+        const property = input[key];
+        formData.append(
+          key,
+          property instanceof Blob
+            ? property
+            : typeof property === "object" && property !== null
+              ? JSON.stringify(property)
+              : `${property}`,
+        );
+        return formData;
+      }, new FormData()),
+    [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),
+  };
+
+  protected mergeRequestParams(
+    params1: RequestParams,
+    params2?: RequestParams,
+  ): RequestParams {
+    return {
+      ...this.baseApiParams,
+      ...params1,
+      ...(params2 || {}),
+      headers: {
+        ...(this.baseApiParams.headers || {}),
+        ...(params1.headers || {}),
+        ...((params2 && params2.headers) || {}),
+      },
+    };
+  }
+
+  protected createAbortSignal = (
+    cancelToken: CancelToken,
+  ): AbortSignal | undefined => {
+    if (this.abortControllers.has(cancelToken)) {
+      const abortController = this.abortControllers.get(cancelToken);
+      if (abortController) {
+        return abortController.signal;
+      }
+      return void 0;
+    }
+
+    const abortController = new AbortController();
+    this.abortControllers.set(cancelToken, abortController);
+    return abortController.signal;
+  };
+
+  public abortRequest = (cancelToken: CancelToken) => {
+    const abortController = this.abortControllers.get(cancelToken);
+
+    if (abortController) {
+      abortController.abort();
+      this.abortControllers.delete(cancelToken);
+    }
+  };
+
+  public request = async <T = any, E = any>({
+    body,
+    secure,
+    path,
+    type,
+    query,
+    format,
+    baseUrl,
+    cancelToken,
+    ...params
+  }: FullRequestParams): Promise<HttpResponse<T, E>> => {
+    const secureParams =
+      ((typeof secure === "boolean" ? secure : this.baseApiParams.secure) &&
+        this.securityWorker &&
+        (await this.securityWorker(this.securityData))) ||
+      {};
+    const requestParams = this.mergeRequestParams(params, secureParams);
+    const queryString = query && this.toQueryString(query);
+    const payloadFormatter = this.contentFormatters[type || ContentType.Json];
+    const responseFormat = format || requestParams.format;
+
+    return this.customFetch(
+      `${baseUrl || this.baseUrl || ""}${path}${queryString ? `?${queryString}` : ""}`,
+      {
+        ...requestParams,
+        headers: {
+          ...(requestParams.headers || {}),
+          ...(type && type !== ContentType.FormData
+            ? { "Content-Type": type }
+            : {}),
+        },
+        signal:
+          (cancelToken
+            ? this.createAbortSignal(cancelToken)
+            : requestParams.signal) || null,
+        body:
+          typeof body === "undefined" || body === null
+            ? null
+            : payloadFormatter(body),
+      },
+    ).then(async (response) => {
+      const r = response.clone() as HttpResponse<T, E>;
+      r.data = null as unknown as T;
+      r.error = null as unknown as E;
+
+      const data = !responseFormat
+        ? r
+        : await response[responseFormat]()
+            .then((data) => {
+              if (r.ok) {
+                r.data = data;
+              } else {
+                r.error = data;
+              }
+              return r;
+            })
+            .catch((e) => {
+              r.error = e;
+              return r;
+            });
+
+      if (cancelToken) {
+        this.abortControllers.delete(cancelToken);
+      }
+
+      if (!response.ok) throw data;
+      return data;
+    });
+  };
+}
+
+/**
+ * @title API V1
+ * @version v1
+ */
+export class Api<
+  SecurityDataType extends unknown,
+> extends HttpClient<SecurityDataType> {
+  api = {
+    /**
+     * No description
+     *
+     * @tags Users
+     * @name V1LoginCreate
+     * @summary ユーザーのログイン
+     * @request POST:/api/v1/login
+     */
+    v1LoginCreate: (
+      data: {
+        /** @example "test@example.com" */
+        email: string;
+        /** @example "password123" */
+        password: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        {
+          /** @example 200 */
+          status?: number;
+          /** @example "ログインに成功しました" */
+          message?: string;
+          user?: {
+            /** @example 1 */
+            id?: number;
+            /** @example "test@example.com" */
+            email?: string;
+            /** @example "テストユーザー" */
+            name?: string;
+          };
+        },
+        {
+          /** @example 401 */
+          status?: number;
+          /** @example "メールアドレスか、パスワードが不正です" */
+          message?: string;
+        }
+      >({
+        path: `/api/v1/login`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+  };
+}

--- a/frontend/src/types/generated/Api.ts
+++ b/frontend/src/types/generated/Api.ts
@@ -271,6 +271,56 @@ export class Api<
      * No description
      *
      * @tags Users
+     * @name V1UserCreate
+     * @summary ユーザーのサインアップ
+     * @request POST:/api/v1/user
+     */
+    v1UserCreate: (
+      data: {
+        /** @example "test@example.com" */
+        email: string;
+        /** @example "password123" */
+        password: string;
+        /** @example "password123" */
+        password_confirmation: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        {
+          /** @example 200 */
+          status?: number;
+          /** @example "サインアップに成功しました" */
+          message?: string;
+          user?: {
+            /** @example 1 */
+            id?: number;
+            /** @example "test@example.com" */
+            email?: string;
+            /** @example "test" */
+            name?: string;
+          };
+        },
+        {
+          /** @example 422 */
+          status?: number;
+          /** @example "サインアップできませんでした。" */
+          message?: string;
+          errors?: string[];
+        }
+      >({
+        path: `/api/v1/user`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Users
      * @name V1LoginCreate
      * @summary ユーザーのログイン
      * @request POST:/api/v1/login

--- a/rails/app/controllers/api/v1/users/registrations_controller.rb
+++ b/rails/app/controllers/api/v1/users/registrations_controller.rb
@@ -9,6 +9,10 @@ class Api::V1::Users::RegistrationsController < Devise::RegistrationsController
     user = User.new(sign_up_params)
 
     if user.save
+      payload = { user_id: user.id, exp: 24.hours.from_now.to_i }
+      token = JWT.encode(payload, Rails.application.secrets.secret_key_base)
+
+      response.set_header('Authorization', "Bearer #{token}")
       render json: {
         status: { code: 200, message: 'サインアップできました' },
         user: user.slice(:id, :email, :name)

--- a/rails/spec/integration/api/v1/users/registrations_spec.rb
+++ b/rails/spec/integration/api/v1/users/registrations_spec.rb
@@ -1,0 +1,54 @@
+require 'swagger_helper'
+
+RSpec.describe "Api::V1::Users::Registration", type: :request do
+  path '/api/v1/user' do
+    post 'ユーザーのサインアップ' do
+      tags 'Users'
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: :credentials, in: :body, schema: {
+        type: :object,
+        required: ['email', 'password', 'password_confirmation'],
+        properties: {
+          email: { type: :string, example: 'test@example.com' },
+          password: { type: :string, example: 'password123' },
+          password_confirmation: { type: :string, example: 'password123' }
+        }
+      }
+
+      response '200', 'サインアップ成功' do
+        schema type: :object,
+        properties: {
+          status: { type: :integer, example: 200 },
+          message: { type: :string, example: 'サインアップに成功しました' },
+          user: {
+            type: :object,
+            properties: {
+              id: { type: :integer, example: 1 },
+              email: { type: :string, example: 'test@example.com' },
+              name: { type: :string, example: 'test' }
+            }
+          }
+        }
+        let(:credentials) { { email: 'test@example.com', password: 'password123', password_confirmation: 'password123' } }
+
+        run_test!
+      end
+
+      response '422', 'サインアップ失敗' do
+        schema type: :object,
+        properties: {
+          status: { type: :integer, example: 422 },
+          message: { type: :string, example: 'サインアップできませんでした。' },
+          errors: {
+            type: :array,
+            items: { type: :string }
+          }
+        }
+        let(:credentials) { { email: 'test@example.com', password: 'password123', password_confirmation: 'aaa' } }
+        run_test!
+      end
+    end
+  end
+end

--- a/rails/spec/integration/api/v1/users/registrations_spec.rb
+++ b/rails/spec/integration/api/v1/users/registrations_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Api::V1::Users::Registration", type: :request do
           message: { type: :string, example: 'サインアップに成功しました' },
           user: {
             type: :object,
+            required: ['id, email', 'name'],
             properties: {
               id: { type: :integer, example: 1 },
               email: { type: :string, example: 'test@example.com' },

--- a/rails/spec/integration/api/v1/users/registrations_spec.rb
+++ b/rails/spec/integration/api/v1/users/registrations_spec.rb
@@ -9,11 +9,12 @@ RSpec.describe "Api::V1::Users::Registration", type: :request do
 
       parameter name: :credentials, in: :body, schema: {
         type: :object,
-        required: ['email', 'password', 'password_confirmation'],
+        required: ['email', 'password', 'password_confirmation', 'name'],
         properties: {
           email: { type: :string, example: 'test@example.com' },
           password: { type: :string, example: 'password123' },
-          password_confirmation: { type: :string, example: 'password123' }
+          password_confirmation: { type: :string, example: 'password123' },
+          name: { type: :string, example: 'test'}
         }
       }
 

--- a/rails/swagger/v1/swagger.yaml
+++ b/rails/swagger/v1/swagger.yaml
@@ -10,6 +10,74 @@ components:
       scheme: bearer
       bearerFormat: JWT
 paths:
+  "/api/v1/user":
+    post:
+      summary: ユーザーのサインアップ
+      tags:
+      - Users
+      parameters: []
+      responses:
+        '200':
+          description: サインアップ成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    example: 200
+                  message:
+                    type: string
+                    example: サインアップに成功しました
+                  user:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        example: 1
+                      email:
+                        type: string
+                        example: test@example.com
+                      name:
+                        type: string
+                        example: test
+        '422':
+          description: サインアップ失敗
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    example: 422
+                  message:
+                    type: string
+                    example: サインアップできませんでした。
+                  errors:
+                    type: array
+                    items:
+                      type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - email
+              - password
+              - password_confirmation
+              properties:
+                email:
+                  type: string
+                  example: test@example.com
+                password:
+                  type: string
+                  example: password123
+                password_confirmation:
+                  type: string
+                  example: password123
   "/api/v1/login":
     post:
       summary: ユーザーのログイン

--- a/rails/swagger/v1/swagger.yaml
+++ b/rails/swagger/v1/swagger.yaml
@@ -68,6 +68,7 @@ paths:
               - email
               - password
               - password_confirmation
+              - name
               properties:
                 email:
                   type: string
@@ -78,6 +79,9 @@ paths:
                 password_confirmation:
                   type: string
                   example: password123
+                name:
+                  type: string
+                  example: test
   "/api/v1/login":
     post:
       summary: ユーザーのログイン


### PR DESCRIPTION
## 概要

URL: https://www.notion.so/21e2946467fd80bc8cf8e461efbf2268?v=21e2946467fd80138aed000c282b35d0&p=23a2946467fd80ceadead879ba4c9235&pm=s
## 詳細

1. Next.jsの実装はリョウが作ってくれたディレクトリを真似て作成したけど間違っていないか。
 
2. ログインの時、フロント側にUserのデータを送る仕様にしていたので新規作成時も同じ形にしました。その過程で、API仕様書のリクエストとレスポンスに関しても微修正を加えた！(赤になっているところを変更して、新規登録できているから問題ないと思うから念の為見てくれたら嬉しい)
 #### API仕様書
URL: https://docs.google.com/spreadsheets/d/1S32O5oUJoGu4VB9I02e14T5xMTGuQAgFs6mZY6_HZrA/edit?gid=359673284#gid=359673284

3. railsってpassword_confirmationってスネークケースで対応するから、Next.js側でもスネークケースで記載したんよ。変換する必要があればやるけどどう？？

4. frontend/src/types/generated/Api.tsの見方(使い方がよくわからん・・・笑)
## 動作確認

### 新規登録画面
<img width="1440" height="900" alt="スクリーンショット 2025-07-27 7 18 29" src="https://github.com/user-attachments/assets/5601126b-3786-4a67-be92-b1b2875ee593" />


### 新規登録成功時の遷移(マイページ)
<img width="1440" height="900" alt="スクリーンショット 2025-07-27 7 15 17" src="https://github.com/user-attachments/assets/c9e3bd8e-899c-4dcc-ae46-bac099b3e4aa" />


### SwaggerUI(サインアップ)
<img width="1440" height="900" alt="スクリーンショット 2025-07-27 7 07 48" src="https://github.com/user-attachments/assets/42364498-7433-45e5-9d87-6cd270b30c23" />

## その他

<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください  
-->

## 参考情報

<!--
参考記事の url などを記載しましょう  
-->
