### PR TITLE
18【Rails】診断履歴一覧API作成

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -43,6 +43,8 @@ gem "enum_help"
 
 gem "ruby-openai"
 
+gem "active_model_serializers", "~> 0.10.12"
+
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 # gem "jbuilder"
 

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -50,6 +50,11 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_model_serializers (0.10.15)
+      actionpack (>= 4.1)
+      activemodel (>= 4.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (7.1.5.1)
       activesupport (= 7.1.5.1)
       globalid (>= 0.3.6)
@@ -92,6 +97,8 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (12.0.0)
+    case_transform (0.2)
+      activesupport
     childprocess (5.1.0)
       logger (~> 1.5)
     coderay (1.1.3)
@@ -164,6 +171,7 @@ GEM
     json-schema (5.1.1)
       addressable (~> 2.8)
       bigdecimal (~> 3.1)
+    jsonapi-renderer (0.2.2)
     jwt (2.10.2)
       base64
     kaminari (1.2.2)
@@ -410,6 +418,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.12)
   bootsnap
   bullet
   config

--- a/rails/app/controllers/api/v1/diagnoses_controller.rb
+++ b/rails/app/controllers/api/v1/diagnoses_controller.rb
@@ -1,30 +1,30 @@
 class Api::V1::DiagnosesController < Api::V1::BaseController
   require "openai"
   def create
-    file_type = ['image/jpeg', 'image/png']
-    base64_image = File.read(Rails.root.join('lib', 'diagnosis_image1.txt')).strip
-    image = 'data:image/jpeg;base64,' + base64_image
+    base64_image = File.read(Rails.root.join("lib", "diagnosis_image1.txt")).strip
+    image = "data:image/jpeg;base64,#{base64_image}"
 
     data_json = Diag::Json::JsonExportService.new.call
     weeds_json = data_json[:weeds_name_to_json]
 
     begin
       data = Diag::Ai::WeedIdentificationService.new(weeds_json: weeds_json, image: image).call
-    rescue Diag::Errors::RateLimitExceeded => e
-      render json: { error: "OpenAIの利用制限を超えました" }, status: 429 and return
+    rescue Diag::Errors::RateLimitExceeded
+      render json: { error: "OpenAIの利用制限を超えました" }, status: :too_many_requests and return
     rescue Diag::Errors::InvalidResponseFormat => e
-      render json: { error: "OpenAIの応答が不正です: #{e.message}" }, status: 400 and return
+      render json: { error: "OpenAIの応答が不正です: #{e.message}" }, status: :bad_request and return
     rescue Diag::Errors::OpenAiCallFailed => e
-      render json: { error: "OpenAI呼び出しエラー: #{e.message}" }, status: 500 and return
+      render json: { error: "OpenAI呼び出しエラー: #{e.message}" }, status: :internal_server_error and return
     rescue => e
       Rails.logger.error("想定外の例外: #{e.class} - #{e.message}")
       Rails.logger.error(e.backtrace.join("\n"))
-      render json: { error: "予期せぬエラーが発生しました: #{e.class}" }, status: 500 and return
+      render json: { error: "予期せぬエラーが発生しました: #{e.class}" }, status: :internal_server_error and return
     end
 
     vegetable_name, weed_name, soil_data, reason = Diag::Json::SearchWeedService.new(data).call
 
-    id = Diag::Db::SaveRecordService.new(vegetable_name: vegetable_name, weed_name: weed_name, soil_data: soil_data, reason: reason, current_user: current_user).call
+    id = Diag::Db::SaveRecordService.new(vegetable_name: vegetable_name, weed_name: weed_name, soil_data: soil_data, reason: reason,
+                                         current_user: current_user).call
 
     render json: id, status: :ok
   end

--- a/rails/app/controllers/api/v1/histories_controller.rb
+++ b/rails/app/controllers/api/v1/histories_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::HistoriesController < Api::V1::BaseController
     if diagnoses.exists?
       render json: diagnoses, each_serializer: ::DiagnosisSerializer
     else
-      render json: { message: "診断履歴がありません。" }
+      render json: []
     end
   end
 

--- a/rails/app/controllers/api/v1/histories_controller.rb
+++ b/rails/app/controllers/api/v1/histories_controller.rb
@@ -1,5 +1,11 @@
 class Api::V1::HistoriesController < Api::V1::BaseController
   def index
+    diagnoses = current_user.diagnoses.includes(:weed, :soil, :vegetable)
+    if diagnoses.exists?
+      render json: diagnoses, each_serializer: ::DiagnosisSerializer
+    else
+      render json: { message: "診断履歴がありません。" }
+    end
   end
 
   def show

--- a/rails/app/controllers/api/v1/users/sessions_controller.rb
+++ b/rails/app/controllers/api/v1/users/sessions_controller.rb
@@ -24,7 +24,7 @@ class Api::V1::Users::SessionsController < Api::V1::BaseController
     end
 
     begin
-      JWT.decode(token, Rails.application.credentials.devise[:jwt_secret_key], true, { algorithms: ['HS256'] }).first
+      JWT.decode(token, Rails.application.credentials.devise[:jwt_secret_key], true, { algorithms: ["HS256"] }).first
 
       render json: { status: 200, message: "ログアウトに成功しました" }, status: :ok
     rescue JWT::ExpiredSignature

--- a/rails/app/serializers/diagnosis_serializer.rb
+++ b/rails/app/serializers/diagnosis_serializer.rb
@@ -1,0 +1,55 @@
+class DiagnosisSerializer < ActiveModel::Serializer
+  attributes :id, :diagnosed_at, :image_url, :weed_name, :weed_description, :soil_type,
+             :soil_description, :recommended_vegetable, :vegetable_difficulty, :vegetable_season, :vegetable_description, :result
+
+  def diagnosed_at
+    object.created_at.iso8601
+  end
+
+  def image_url
+    object.image_url
+  end
+
+  def weed_name
+    object.weed&.name
+  end
+
+  def weed_description
+    object.weed&.description
+  end
+
+  def soil_type
+    object.soil&.pH_level_before_type_cast || 10
+  end
+
+  def soil_description
+    object.soil&.description
+  end
+
+  def recommended_vegetable
+    object.vegetable&.name
+  end
+
+  def vegetable_difficulty
+    case object.vegetable&.difficulty
+    when 0 then "易"
+    when 1 then "普"
+    when 2 then "難"
+    else "不明"
+    end
+  end
+
+  def vegetable_season
+    case object.vegetable&.season
+    when 0 then ["春"]
+    when 1 then ["夏"]
+    when 2 then ["秋"]
+    when 3 then ["冬"]
+    else []
+    end
+  end
+
+  def vegetable_description
+    object.vegetable&.description
+  end
+end

--- a/rails/app/serializers/diagnosis_serializer.rb
+++ b/rails/app/serializers/diagnosis_serializer.rb
@@ -32,9 +32,9 @@ class DiagnosisSerializer < ActiveModel::Serializer
 
   def vegetable_difficulty
     case object.vegetable&.difficulty
-    when 0 then "易"
-    when 1 then "普"
-    when 2 then "難"
+    when 0 then "易しい"
+    when 1 then "普通"
+    when 2 then "難しい"
     else "不明"
     end
   end

--- a/rails/app/services/diag/ai/weed_identification_service.rb
+++ b/rails/app/services/diag/ai/weed_identification_service.rb
@@ -6,34 +6,34 @@ class Diag::Ai::WeedIdentificationService
 
   def call
     weeds = @weeds_json
-    puts "#{format_weed_list(weeds)}"
+    Rails.logger.debug format_weed_list(weeds).to_s
     client = OpenAI::Client.new(
-      access_token: Rails.application.credentials.chatgpt_api_key
+      access_token: Rails.application.credentials.chatgpt_api_key,
     )
     user_prompt = <<~TEXT
-      受け取った画像に対して、
-      その画像に写っている雑草の名前を教えてください。
-      なお、雑草は「雑草一覧」から選択してください。
+        受け取った画像に対して、
+        その画像に写っている雑草の名前を教えてください。
+        なお、雑草は「雑草一覧」から選択してください。
 
-      ## 雑草一覧（以下から1つ選んでください）
-      #{format_weed_list(weeds)}
+        ## 雑草一覧（以下から1つ選んでください）
+        #{format_weed_list(weeds)}
 
-    【重要】
-      - 出力する雑草名は、必ず「雑草一覧」にある **1種類** のみ。
-      - 一覧にない雑草名・学名・別名・形容詞などは **絶対に使用しないでください**。
-      - 「雑草一覧」に含まれない名前を出力した場合はエラーとみなします。
+      【重要】
+        - 出力する雑草名は、必ず「雑草一覧」にある **1種類** のみ。
+        - 一覧にない雑草名・学名・別名・形容詞などは **絶対に使用しないでください**。
+        - 「雑草一覧」に含まれない名前を出力した場合はエラーとみなします。
 
-      【禁止事項】
-      - 上記一覧にない雑草名を出力すること
-      - 複数の雑草名を出力すること
-      - 別名・学名・英語名・画像の説明・その他のコメントを出力すること
+        【禁止事項】
+        - 上記一覧にない雑草名を出力すること
+        - 複数の雑草名を出力すること
+        - 別名・学名・英語名・画像の説明・その他のコメントを出力すること
 
-      ## 出力JSONフォーマット(厳守)
-      以下の形式でJSONのみ出力してください（前後に、```jsonなどの余計な説明は絶対に不要です）:
+        ## 出力JSONフォーマット(厳守)
+        以下の形式でJSONのみ出力してください（前後に、```jsonなどの余計な説明は絶対に不要です）:
 
-      {
-        "weed_name": "ユウゲショウ"
-      }
+        {
+          "weed_name": "ユウゲショウ"
+        }
 
     TEXT
 
@@ -44,17 +44,16 @@ class Diag::Ai::WeedIdentificationService
           messages: [
             { role: "system", content: "あなたはJSON生成AIです。必ず純粋なJSONデータのみを返してください。絶対に```jsonなどの説明文や補足、余計な文章は一切含めてはいけません。" },
             { role: "user", content: [
-                { type: "text", text: user_prompt },
-                { type: "image_url", image_url: { url: @image} }
-              ]
-            }
-          ]
-        }
+              { type: "text", text: user_prompt },
+              { type: "image_url", image_url: { url: @image } },
+            ] },
+          ],
+        },
       )
     rescue Faraday::TooManyRequestsError => e
       Rails.logger.warn("OpenAI APIのレート制限を超えました: #{e.message}")
       raise Diag::Errors::RateLimitExceeded, e.message
-    rescue StandardError => e
+    rescue => e
       Rails.logger.error("OpenAI API呼び出しに失敗しました: #{e.class} - #{e.message}")
       raise Diag::Errors::OpenAiCallFailed, "#{e.class}: #{e.message}"
     end
@@ -65,9 +64,10 @@ class Diag::Ai::WeedIdentificationService
     Rails.logger.debug("GPTの生データ: #{data_str}")
     raise StandardError, "OpenAIからのレスポンスが空です" unless data_str
 
-    json_start_index = data_str.index('{')
+    json_start_index = data_str.index("{")
 
     raise StandardError, "OpenAIの出力が不完全です（JSONの開始が見つかりません）" unless json_start_index
+
     json_string = data_str[json_start_index..]
 
     # OpenAIの出力が不完全/JSONの形式が不正
@@ -81,11 +81,12 @@ class Diag::Ai::WeedIdentificationService
       raise Diag::Errors::InvalidResponseFormat, "OpenAIの出力が不正なJSON形式です: #{e.message}"
     end
 
-    return data
+    data
   end
 
   def format_weed_list(json)
-    return "" if json.nil? || json.empty?
-    JSON.parse(json).map { |w| w['name'] }.join("\n")
+    return "" if json.blank?
+
+    JSON.parse(json).map {|w| w["name"] }.join("\n")
   end
 end

--- a/rails/app/services/diag/db/save_record_service.rb
+++ b/rails/app/services/diag/db/save_record_service.rb
@@ -19,12 +19,12 @@ class Diag::Db::SaveRecordService
       SoilVegetableRelation.create!(
         soil_id: @soil.id,
         vegetable_id: @vegetable.id,
-        reason: @reason
+        reason: @reason,
       )
       WeedSoilRelation.create!(
         weed_id: @weed.id,
         soil_id: @soil.id,
-        notes: @reason
+        notes: @reason,
       )
       @diagnosis = Diagnosis.create!(
         user_id: @user.id,
@@ -32,10 +32,10 @@ class Diag::Db::SaveRecordService
         soil_id: @soil.id,
         vegetable_id: @vegetable.id,
         image_url: "",
-        result: @reason
+        result: @reason,
       )
     end
-    return { id: @diagnosis.id }
+    { id: @diagnosis.id }
   rescue => e
     Rails.logger.error("SaveRecordService エラー発生: #{e.class} - #{e.message}")
     Rails.logger.error(e.backtrace.join("\n"))

--- a/rails/app/services/diag/json/json_export_service.rb
+++ b/rails/app/services/diag/json/json_export_service.rb
@@ -5,6 +5,6 @@ class Diag::Json::JsonExportService
         name: weed.name,
       }
     end
-    return { weeds_name_to_json: weeds.to_json }
+    { weeds_name_to_json: weeds.to_json }
   end
 end

--- a/rails/app/services/diag/json/search_weed_service.rb
+++ b/rails/app/services/diag/json/search_weed_service.rb
@@ -1,13 +1,13 @@
-require 'json'
+require "json"
 class Diag::Json::SearchWeedService
   def initialize(data)
     @data = data
   end
 
   def call
-    file_path = Rails.root.join('lib', 'json', 'weed_vegetable_relations.json')
+    file_path = Rails.root.join("lib", "json", "weed_vegetable_relations.json")
     json_data = JSON.parse(File.read(file_path))
-    matched_data = json_data.find { |data| data["weed_name"] == @data["weed_name"]  }
+    matched_data = json_data.find {|data| data["weed_name"] == @data["weed_name"] }
 
     return nil unless matched_data
 
@@ -18,7 +18,7 @@ class Diag::Json::SearchWeedService
     soil_data = {
       pH_level: matched_data["pH_level"].to_i,
       drainage: matched_data["drainage"].to_i,
-      fertility: matched_data["fertility"].to_i
+      fertility: matched_data["fertility"].to_i,
     }
 
     return vegetable_name, weed_name, soil_data, reason

--- a/rails/config/application.rb
+++ b/rails/config/application.rb
@@ -44,6 +44,8 @@ module Myapp
     config.enable_reloading = true
     config.autoload_paths << Rails.root.join('app/errors')
     config.eager_load_paths << Rails.root.join('app/errors')
+    config.autoload_paths << Rails.root.join('app/serializers')
+    config.eager_load_paths << Rails.root.join('app/serializers')
     # Warden::JWTAuth::Middleware を除去（無効化）
     config.middleware.delete Warden::JWTAuth::Middleware
   end

--- a/rails/db/seeds/weeds/weeds.rb
+++ b/rails/db/seeds/weeds/weeds.rb
@@ -243,7 +243,7 @@ weeds = [
     name: "ハキダメギク",
     scientific_name: "Galinsoga quadriradiata",
     description: "一見地味だが繁殖力は非常に高い。中南米原産の外来種。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "コメツブウマゴヤシ",
@@ -255,7 +255,7 @@ weeds = [
     name: "アメリカフウロ",
     scientific_name: "Geranium carolinianum",
     description: "切れ込みのある葉が特徴。春から初夏にかけて見られる。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ノビル",
@@ -267,7 +267,7 @@ weeds = [
     name: "セリ",
     scientific_name: "Oenanthe javanica",
     description: "水辺に生育する多年草。春の七草のひとつ。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "シロザ",
@@ -279,7 +279,7 @@ weeds = [
     name: "タビラコ",
     scientific_name: "Lapsana apogonoides",
     description: "春の七草の「ホトケノザ」とされるキク科の植物。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "チドメグサ",
@@ -291,7 +291,7 @@ weeds = [
     name: "ハマスゲ",
     scientific_name: "Cyperus rotundus",
     description: "地下茎で増える多年草。根絶が難しい。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ネズミムギ",
@@ -321,7 +321,7 @@ weeds = [
     name: "ヒエ",
     scientific_name: "Echinochloa oryzicola",
     description: "水田の雑草として有名。穂が密集しているのが特徴。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "カタヒバリ",
@@ -387,7 +387,7 @@ weeds = [
     name: "ヤブカラシ",
     scientific_name: "Cayratia japonica",
     description: "つる性の多年草。繁殖力が強く、他の植物に絡みつく。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "アレチヌスビトハギ",
@@ -399,7 +399,7 @@ weeds = [
     name: "オオイヌノフグリ",
     scientific_name: "Veronica persica",
     description: "青い小花を咲かせる春の雑草。道端や畑に多い。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "タチイヌノフグリ",
@@ -411,25 +411,25 @@ weeds = [
     name: "イヌホオズキ",
     scientific_name: "Solanum nigrum",
     description: "ナス科の一年草。小さな黒い実をつける雑草。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ヤブジラミ",
     scientific_name: "Torilis japonica",
     description: "セリ科の一年草。葉が細かく切れ込んでいるのが特徴。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ヒルガオ",
     scientific_name: "Calystegia sepium",
     description: "つる性の多年草。朝に白や薄ピンクの花を咲かせる。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "スギナ",
     scientific_name: "Equisetum arvense",
     description: "地下茎で広がるシダ植物。春に細長い茎を出す。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ヤブカンゾウ",
@@ -453,19 +453,19 @@ weeds = [
     name: "コマツヨイグサ",
     scientific_name: "Oenothera biennis",
     description: "黄色い花を夜に咲かせる多年草。畑の雑草。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "イヌタデ",
     scientific_name: "Persicaria longiseta",
     description: "赤みを帯びた茎を持つ一年草。畑や水辺に多い。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "アカツメクサ",
     scientific_name: "Trifolium pratense",
     description: "赤紫色の花をつける多年草。牧草としても使われる。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "チチコグサ",
@@ -483,7 +483,7 @@ weeds = [
     name: "カワラケツメイ",
     scientific_name: "Cassia tora",
     description: "豆科の一年草。黄色い花をつける。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ヒナゲシ",
@@ -501,7 +501,7 @@ weeds = [
     name: "ヤマノイモ",
     scientific_name: "Dioscorea japonica",
     description: "つる性の多年草。山地の林縁などに生える。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "オオバコモドキ",
@@ -519,7 +519,7 @@ weeds = [
     name: "アキノノゲシ",
     scientific_name: "Sonchus asper",
     description: "キク科の多年草。トゲが多く葉が荒い。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ホソバアカザ",
@@ -585,19 +585,19 @@ weeds = [
     name: "コカラスムギ",
     scientific_name: "Avena strigosa",
     description: "イネ科の一年草。カラスムギに似る。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "トキワハゼ",
     scientific_name: "Mazus pumilus",
     description: "小型の一年草。紫色の花が特徴。",
-    image_url: ""
+    image_url: "",
   },
- {
+  {
     name: "オオアワガエリ",
     scientific_name: "Apera spica-venti",
     description: "イネ科の一年草。風に揺れる穂が特徴的。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "キツネノマゴ",
@@ -615,7 +615,7 @@ weeds = [
     name: "オオカワヂシャ",
     scientific_name: "Rorippa indica",
     description: "アブラナ科の多年草。湿った場所に生える。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ミズヒキ",
@@ -627,7 +627,7 @@ weeds = [
     name: "ヒメオドリコソウ",
     scientific_name: "Lamium purpureum",
     description: "シソ科の多年草。紫色の花が咲く。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "スズメノエンドウ",
@@ -651,13 +651,13 @@ weeds = [
     name: "ヤブツルアズキ",
     scientific_name: "Vigna angularis var. nipponensis",
     description: "マメ科のつる性多年草。赤い豆がなる。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "アキノタムラソウ",
     scientific_name: "Leonurus japonicus",
     description: "シソ科の多年草。秋に紫色の花を咲かせる。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "オニノゲシ",
@@ -669,7 +669,7 @@ weeds = [
     name: "ノアザミ",
     scientific_name: "Cirsium japonicum",
     description: "キク科の多年草。紫色の花が咲く。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ツルムラサキ",
@@ -681,25 +681,25 @@ weeds = [
     name: "ミズバショウ",
     scientific_name: "Lysichiton camtschatcensis",
     description: "湿地に生える多年草。白い花が特徴的。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "オオキンケイギク",
     scientific_name: "Coreopsis lanceolata",
     description: "鮮やかな黄色の花を咲かせる多年草。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "オオブタクサ",
     scientific_name: "Ambrosia trifida",
     description: "大型の一年草。花粉症の原因となることもある。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ヒルザキツキミソウ",
     scientific_name: "Oenothera speciosa",
     description: "ピンクの花を咲かせる多年草。庭にも植えられる。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ススキ",
@@ -711,13 +711,13 @@ weeds = [
     name: "キクイモ",
     scientific_name: "Helianthus tuberosus",
     description: "黄色い花を咲かせる多年草。地下茎で増える。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "タネツケバナ",
     scientific_name: "Rorippa indica",
     description: "水田周辺に多い小型の一年草。早春に開花。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "フユノハナワラビ",
@@ -735,13 +735,13 @@ weeds = [
     name: "シラヤマギク",
     scientific_name: "Aster yomena",
     description: "白い花を咲かせる多年草。山地に自生。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ツリガネニンジン",
     scientific_name: "Codonopsis lanceolata",
     description: "鐘形の青紫の花を咲かせる多年草。山野に自生。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "カワラナデシコ",
@@ -759,19 +759,19 @@ weeds = [
     name: "ノコンギク",
     scientific_name: "Aster ageratoides",
     description: "紫色の花を咲かせる多年草。秋に見られる。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "カントウタンポポ",
     scientific_name: "Taraxacum platycarpum",
     description: "日本固有種のタンポポ。黄色い花が特徴。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "シソ",
     scientific_name: "Perilla frutescens",
     description: "香りのある一年草。葉は料理に使われる。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ヒメジソ",
@@ -783,7 +783,7 @@ weeds = [
     name: "ヤブマオ",
     scientific_name: "Urera laciniata",
     description: "低木性の多年草。葉が大きく繁茂する。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "コアカザ",
@@ -795,7 +795,7 @@ weeds = [
     name: "ヒメシロザ",
     scientific_name: "Chenopodium murale",
     description: "シロザに似る小型の一年草。庭に多い。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "アキノキリンソウ",
@@ -813,7 +813,7 @@ weeds = [
     name: "ツルニチニチソウ",
     scientific_name: "Vinca major",
     description: "つる性の多年草。紫青色の花が特徴で、グランドカバーに利用される。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ミゾソバ",
@@ -831,7 +831,7 @@ weeds = [
     name: "ヌスビトハギ",
     scientific_name: "Desmodium podocarpum",
     description: "マメ科の多年草で、実が衣服に付きやすい。秋に花が咲く。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "オオチドメ",
@@ -855,55 +855,55 @@ weeds = [
     name: "シロバナタンポポ",
     scientific_name: "Taraxacum albidum",
     description: "白い花を咲かせる日本固有のタンポポの一種。西日本に多い。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ハハコグサ",
     scientific_name: "Gnaphalium affine",
     description: "春の七草の一つ。白い綿毛に包まれた花を咲かせる。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ヘクソカズラ",
     scientific_name: "Paederia scandens",
     description: "独特な臭いを持つつる植物。白い縁のある小さな花を咲かせる。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ユウゲショウ",
     scientific_name: "Oenothera rosea",
     description: "ピンク色のかわいらしい花を咲かせる帰化植物。道端に多い。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "セイヨウタンポポ",
     scientific_name: "Taraxacum officinale",
     description: "外来種のタンポポ。総苞片が反り返るのが特徴。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "マメグンバイナズナ",
     scientific_name: "Lepidium virginicum",
     description: "白い小花とハート型の種が特徴的な帰化植物。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "イタドリ",
     scientific_name: "Fallopia japonica",
     description: "大きな葉と赤味を帯びた茎が特徴。河原や空き地に繁茂。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ネジバナ",
     scientific_name: "Spiranthes sinensis",
     description: "花が螺旋状に並ぶラン科の多年草。芝生などに自生。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "コオニタビラコ",
     scientific_name: "Lapsana apogonoides",
     description: "タンポポに似た黄色い花を咲かせる一年草。春の七草の一つ「ほとけのざ」。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "カキドオシ",
@@ -915,13 +915,13 @@ weeds = [
     name: "ヘビイチゴ",
     scientific_name: "Duchesnea chrysantha",
     description: "黄色い花を咲かせ、赤い偽果をつける。毒性はないが食用には向かない。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "マツヨイグサ",
     scientific_name: "Oenothera biennis",
     description: "夕方に黄色い花を咲かせる外来植物。夜咲きで虫を引き寄せる。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ナガミヒナゲシ",
@@ -933,31 +933,31 @@ weeds = [
     name: "ブタクサ",
     scientific_name: "Ambrosia artemisiifolia",
     description: "花粉症の原因植物の一つ。葉は羽状に深く切れ込む。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "アカバナユウゲショウ",
     scientific_name: "Oenothera rosea",
     description: "ピンク色の小花を咲かせる外来種。見た目は可憐だが繁殖力が高い。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "イヌビユ",
     scientific_name: "Amaranthus viridis",
     description: "葉が楕円形で先がとがるヒユ科の一年草。夏に群生する。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ムラサキケマン",
     scientific_name: "Corydalis incisa",
     description: "春に紫色の筒状花をつける。ケシ科で毒性があるため注意が必要。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "アオビユ",
     scientific_name: "Amaranthus lividus",
     description: "ヒユ科の雑草。葉に赤紫色の斑点が入ることがある。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ナギナタコウジュ",
@@ -975,25 +975,25 @@ weeds = [
     name: "ツボミオオバコ",
     scientific_name: "Plantago asiatica",
     description: "地面に広がるロゼット状の葉が特徴の多年草。踏みつけに強く道端に多い。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "セイバンモロコシ",
     scientific_name: "Sorghum halepense",
     description: "イネ科の多年草。高く伸び、群落を形成する。外来雑草。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ムラサキツメクサ",
     scientific_name: "Trifolium pratense",
     description: "ピンクの花をつけるクローバーの仲間。マメ科で緑肥にもなる。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ウラジロチチコグサ",
     scientific_name: "Gamochaeta purpurea",
     description: "裏面が白っぽい葉を持つキク科雑草。ドライな場所に好んで生える。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ナヨクサフジ",
@@ -1011,19 +1011,19 @@ weeds = [
     name: "アキノゲシ",
     scientific_name: "Lactuca indica",
     description: "秋に黄色いタンポポに似た花を咲かせる多年草。草丈が高い。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "カラクサナズナ",
     scientific_name: "Lepidium virginicum",
     description: "ロゼット状に広がる葉と十字形の白花が特徴。外来のアブラナ科雑草。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "イノコヅチ",
     scientific_name: "Achyranthes bidentata",
     description: "果実が衣服にくっつく多年草。茎が太く高さ1m近くにもなる。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "カゼクサ",
@@ -1041,7 +1041,7 @@ weeds = [
     name: "ヌカキビ",
     scientific_name: "Panicum bisulcatum",
     description: "稲に似た穂をつけるイネ科雑草。水田周辺に多く見られる。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ヤマトリカブト",
@@ -1071,38 +1071,38 @@ weeds = [
     name: "ナガエツルノゲイトウ",
     scientific_name: "Alternanthera philoxeroides",
     description: "水辺に群生する外来雑草。環境省の要注意外来生物。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "センダングサ",
     scientific_name: "Bidens pilosa",
     description: "「ひっつき虫」として知られるタネを持つ。キク科の外来植物。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ニワゼキショウ",
     scientific_name: "Sisyrinchium rosulatum",
     description: "青紫の小花を咲かせる外来のアヤメ科植物。芝生にも生える。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "カモガヤ",
     scientific_name: "Dactylis glomerata",
     description: "牧草としても使われるが、花粉症の原因としても有名なイネ科植物。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "ツルマメ",
     scientific_name: "Glycine soja",
     description: "大豆の原種とされるつる性植物。夏から秋に紫の花を咲かせる。",
-    image_url: ""
+    image_url: "",
   },
   {
     name: "カタバミモドキ",
     scientific_name: "Oxalis debilis",
     description: "ピンクの花を咲かせる外来のカタバミ。庭に生えやすい。",
-    image_url: ""
-  }
+    image_url: "",
+  },
 ]
 
 weeds.each do |weed|


### PR DESCRIPTION
## 概要
https://www.notion.so/21e2946467fd80bc8cf8e461efbf2268?v=21e2946467fd80138aed000c282b35d0&p=2482946467fd809aaa2fc3c7e59743e4&pm=s

## 詳細

- 診断結果がなかった際の返却をどうするか。何かしらは返した方がいいと思う。(今はmessageを返す形にしてある)
## 動作確認
<img width="1440" height="900" alt="スクリーンショット 2025-08-09 18 33 38" src="https://github.com/user-attachments/assets/f91e66eb-3c52-4e31-b420-cb2dcae3e3ef" />



## その他

- active_model_serializers

## 参考情報

- https://zenn.dev/ddpmntcpbr/books/rna-hands-on/viewer/rails-05#serializer-%E3%81%AE%E8%A8%AD%E8%A8%88
