### PR TITLE
【rails】ログアウトのテストを書いて、フロントエンドで使えるように型の生成を行う

### DIFF
--- a/rails/app/controllers/api/v1/base_controller.rb
+++ b/rails/app/controllers/api/v1/base_controller.rb
@@ -7,16 +7,16 @@ class Api::V1::BaseController < ApplicationController
       token = request.headers["Authorization"]&.split(" ")&.last
 
       if token.blank?
-        render json: { error: "Unauthorized: token missing" }, status: :unauthorized and return
+        render json: { error: "Authorizationヘッダーがありません" }, status: :unauthorized and return
       end
 
       begin
         payload = JWT.decode(token, Rails.application.credentials.devise[:jwt_secret_key], true, { algorithms: ["HS256"] }).first
         @current_user = User.find(payload["user_id"])
       rescue JWT::ExpiredSignature
-        render json: { error: "Unauthorized: token expired" }, status: :unauthorized and return
+        render json: { error: "トークンの有効期限が切れています" }, status: :unauthorized and return
       rescue JWT::DecodeError, ActiveRecord::RecordNotFound
-        render json: { error: "Unauthorized: invalid token" }, status: :unauthorized and return
+        render json: { error: "無効なトークンです" }, status: :unauthorized and return
       end
     end
 

--- a/rails/app/controllers/api/v1/users/registrations_controller.rb
+++ b/rails/app/controllers/api/v1/users/registrations_controller.rb
@@ -10,10 +10,12 @@ class Api::V1::Users::RegistrationsController < ActionController::API
         user: result[:user].as_json(only: [:id, :email, :name]),
       }
     else
+      user = User.new(sign_up_params)
+      user.valid? # バリデーション実行してエラー情報をセット
       render json: {
         status: 422,
         message: "サインアップに失敗しました",
-        errors: result[:user].errors.full_messages,
+        errors: user.errors.full_messages,
       }, status: :unprocessable_entity
     end
   end

--- a/rails/config/environments/test.rb
+++ b/rails/config/environments/test.rb
@@ -65,4 +65,5 @@ Rails.application.configure do
   config.hosts << "localhost"
   config.hosts << "127.0.0.1"
   config.hosts << "www.example.com"
+  config.hosts << /.*/
 end

--- a/rails/spec/integration/api/v1/users/registrations_spec.rb
+++ b/rails/spec/integration/api/v1/users/registrations_spec.rb
@@ -1,1 +1,55 @@
-require "swagger_helper"
+require 'swagger_helper'
+
+RSpec.describe "Api::V1::Users::Registration", type: :request do
+  path '/api/v1/user' do
+    post 'ユーザーのサインアップ' do
+      tags 'Users'
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: :user, in: :body, schema: {
+        type: :object,
+        required: ['email', 'password', 'password_confirmation', 'name'],
+        properties: {
+          email: { type: :string, example: 'test@example.com' },
+          password: { type: :string, example: 'password123' },
+          password_confirmation: { type: :string, example: 'password123' },
+          name: { type: :string, example: 'test' }
+        }
+      }
+
+      response '200', 'サインアップ成功' do
+        schema type: :object,
+        properties: {
+          status: { type: :integer, example: 200 },
+          message: { type: :string, example: 'サインアップに成功しました' },
+          user: {
+            type: :object,
+            required: ['id', 'email', 'name'],
+            properties: {
+              id: { type: :integer, example: 1 },
+              email: { type: :string, example: 'test@example.com' },
+              name: { type: :string, example: 'test' }
+            }
+          }
+        }
+        let(:user) { { user: { email: 'new_email@example.com', password: 'password123', password_confirmation: 'password123', name: 'test' } } }
+        run_test!
+      end
+
+      response '422', 'サインアップ失敗' do
+        schema type: :object,
+        properties: {
+          status: { type: :integer, example: 422 },
+          message: { type: :string, example: 'サインアップに失敗しました' },
+          errors: {
+            type: :array,
+            items: { type: :string }
+          }
+        }
+        let(:user) { { user: { email: 'test@example.com', password: 'password123', password_confirmation: 'aaa', name: 'test' } } }
+        run_test!
+      end
+    end
+  end
+end

--- a/rails/spec/integration/api/v1/users/sessions_spec.rb
+++ b/rails/spec/integration/api/v1/users/sessions_spec.rb
@@ -1,1 +1,125 @@
-require "swagger_helper"
+require 'swagger_helper'
+
+RSpec.describe 'Api::V1::Users::Sessions', type: :request do
+  path '/api/v1/login' do
+    post 'ユーザーのログイン' do
+      tags 'Users'
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: :user, in: :body, schema: {
+        type: :object,
+        required: ['email', 'password'],
+        properties: {
+          email: { type: :string, example: 'test@example.com' },
+          password: { type: :string, example: 'password123' },
+        }
+      }
+
+      response '200', 'ログイン成功' do
+        schema type: :object,
+          properties: {
+            status: { type: :integer, example: 200 },
+            message: { type: :string, example: 'ログインに成功しました' },
+            user: {
+              type: :object,
+              required: ['id', 'email', 'name'],
+              properties: {
+                id: { type: :integer, example: 1 },
+                email: { type: :string, example: 'test@example.com' },
+                name: { type: :string, example: 'テストユーザー' }
+              }
+            }
+          }
+        let!(:existing_user) { User.create(email: 'test@example.com', password: 'password123', name: 'テストユーザー') }
+        let(:user) { { user: { email: existing_user.email, password: 'password123' } } }
+        let(:Host) { 'www.example.com' }
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(response.status).to eq(200)
+          expect(data['message']).to eq('ログインに成功しました')
+        end
+      end
+
+      response '401', 'ログイン失敗（認証エラー）' do
+        schema type: :object,
+          properties: {
+            status: { type: :integer, example: 401 },
+            message: { type: :string, example: 'メールアドレスか、パスワードが不正です' },
+          }
+        let(:user) { { user: { email: 'wrong@example.com', password: 'wrongpass' } } }
+        let(:Host) { 'www.example.com' }
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(response.status).to eq(401)
+          expect(data['message']).to eq('メールアドレスか、パスワードが不正です')
+        end
+      end
+    end
+  end
+
+  path '/api/v1/logout' do
+    delete 'ユーザーのログアウト' do
+      tags 'Users'
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: 'Authorization', in: :header, type: :string, description: 'Bearer token'
+
+      response '200', 'ログアウト成功' do
+        schema type: :object,
+          properties: {
+            status: { type: :integer, example: 200 },
+            message: { type: :string, example: 'ログアウトに成功しました' }
+          }
+        let!(:existing_user) { User.create(email: 'test@example.com', password: 'password123', name: 'テストユーザー') }
+        let(:token) { User::LoginService.new(email: existing_user[:email], password: 'password123').call[:token] }
+        let(:Authorization) { "Bearer #{token}" }
+        let(:Host) { 'www.example.com' }
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(response.status).to eq(200)
+          expect(data['message']).to eq('ログアウトに成功しました')
+        end
+      end
+      response '401', 'Authorizationヘッダーなし' do
+        let(:Authorization) { nil }
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(response.status).to eq(401)
+          expect(data['error']).to eq('Authorizationヘッダーがありません')
+        end
+      end
+
+      response '401', '無効なトークン' do
+        let(:Authorization) { 'Bearer invalid.token.here' }
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(response.status).to eq(401)
+          expect(data['error']).to eq('無効なトークンです')
+        end
+      end
+      response '401', '有効期限切れトークン' do
+        let!(:existing_user) do
+          User.create!(email: 'test2@example.com', password: 'password123', name: 'テストユーザー2')
+        end
+
+        let(:expired_token) do
+          payload = {
+            user_id: existing_user.id,
+            exp: 1.hour.ago.to_i, # 期限切れ
+            jti: SecureRandom.uuid
+          }
+          JWT.encode(payload, Rails.application.credentials.devise[:jwt_secret_key], 'HS256')
+        end
+
+        let(:Authorization) { "Bearer #{expired_token}" }
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(response.status).to eq(401)
+          expect(data['error']).to eq('トークンの有効期限が切れています')
+        end
+      end
+    end
+  end
+end

--- a/rails/spec/swagger_helper.rb
+++ b/rails/spec/swagger_helper.rb
@@ -50,7 +50,17 @@ RSpec.configure do |config|
       },
       # security: [ { bearerAuth: [] } ],
       paths: {},
-    },
+      servers: [
+        {
+          url: 'http://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'www.example.com'
+            }
+          }
+        }
+      ]
+    }
   }
 
   # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.

--- a/rails/swagger/v1/swagger.yaml
+++ b/rails/swagger/v1/swagger.yaml
@@ -32,6 +32,10 @@ paths:
                     example: サインアップに成功しました
                   user:
                     type: object
+                    required:
+                    - id
+                    - email
+                    - name
                     properties:
                       id:
                         type: integer
@@ -54,7 +58,7 @@ paths:
                     example: 422
                   message:
                     type: string
-                    example: サインアップできませんでした。
+                    example: サインアップに失敗しました
                   errors:
                     type: array
                     items:
@@ -105,7 +109,8 @@ paths:
                   user:
                     type: object
                     required:
-                    - id, email
+                    - id
+                    - email
                     - name
                     properties:
                       id:
@@ -145,3 +150,35 @@ paths:
                 password:
                   type: string
                   example: password123
+  "/api/v1/logout":
+    delete:
+      summary: ユーザーのログアウト
+      tags:
+      - Users
+      parameters:
+      - name: Authorization
+        in: header
+        description: Bearer token
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ログアウト成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    example: 200
+                  message:
+                    type: string
+                    example: ログアウトに成功しました
+        '401':
+          description: 有効期限切れトークン
+servers:
+- url: http://{defaultHost}
+  variables:
+    defaultHost:
+      default: www.example.com


### PR DESCRIPTION
## 概要

https://www.notion.so/rails-23f2946467fd80ad83a6f04d217b9562

## 詳細

- 以前pushしていたrails/spec/integration/api/v1/users/sessions_spec.rbとrails/spec/integration/api/v1/users/registrations_spec.rbのデータが消えていたのでGitHubからコピーして最pushしちゃった。

- ログアウト以外の箇所で、sessionsとregistrationsの微調整しちゃったから、それに合わせて多少file change起こってる。

## 動作確認

### テストのコマンド
`RAILS_ENV=test bundle exec rspec ディレクトリ~`

### Swagger.yamlの更新
`RAILS_ENV=test bundle exec rake rswag:specs:swaggerize`

## その他


## 参考情報

<!--
参考記事の url などを記載しましょう  
-->
