### PR TITLE
【Rails】パスワード忘れのときに登録しているメールアドレスにメールを送信できるようにする

### DIFF
--- a/frontend/src/types/generated/Api.ts
+++ b/frontend/src/types/generated/Api.ts
@@ -11,9 +11,9 @@
  */
 
 export type QueryParamsType = Record<string | number, any>;
-export type ResponseFormat = keyof Omit<Body, 'body' | 'bodyUsed'>;
+export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
 
-export interface FullRequestParams extends Omit<RequestInit, 'body'> {
+export interface FullRequestParams extends Omit<RequestInit, "body"> {
   /** set parameter to `true` for call `securityWorker` for this request */
   secure?: boolean;
   /** request path */
@@ -32,18 +32,22 @@ export interface FullRequestParams extends Omit<RequestInit, 'body'> {
   cancelToken?: CancelToken;
 }
 
-export type RequestParams = Omit<FullRequestParams, 'body' | 'method' | 'query' | 'path'>;
+export type RequestParams = Omit<
+  FullRequestParams,
+  "body" | "method" | "query" | "path"
+>;
 
 export interface ApiConfig<SecurityDataType = unknown> {
   baseUrl?: string;
-  baseApiParams?: Omit<RequestParams, 'baseUrl' | 'cancelToken' | 'signal'>;
+  baseApiParams?: Omit<RequestParams, "baseUrl" | "cancelToken" | "signal">;
   securityWorker?: (
-    securityData: SecurityDataType | null
+    securityData: SecurityDataType | null,
   ) => Promise<RequestParams | void> | RequestParams | void;
   customFetch?: typeof fetch;
 }
 
-export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown>
+  extends Response {
   data: D;
   error: E;
 }
@@ -51,25 +55,26 @@ export interface HttpResponse<D extends unknown, E extends unknown = unknown> ex
 type CancelToken = Symbol | string | number;
 
 export enum ContentType {
-  Json = 'application/json',
-  JsonApi = 'application/vnd.api+json',
-  FormData = 'multipart/form-data',
-  UrlEncoded = 'application/x-www-form-urlencoded',
-  Text = 'text/plain',
+  Json = "application/json",
+  JsonApi = "application/vnd.api+json",
+  FormData = "multipart/form-data",
+  UrlEncoded = "application/x-www-form-urlencoded",
+  Text = "text/plain",
 }
 
 export class HttpClient<SecurityDataType = unknown> {
-  public baseUrl: string = 'http://{defaultHost}';
+  public baseUrl: string = "http://{defaultHost}";
   private securityData: SecurityDataType | null = null;
-  private securityWorker?: ApiConfig<SecurityDataType>['securityWorker'];
+  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
   private abortControllers = new Map<CancelToken, AbortController>();
-  private customFetch = (...fetchParams: Parameters<typeof fetch>) => fetch(...fetchParams);
+  private customFetch = (...fetchParams: Parameters<typeof fetch>) =>
+    fetch(...fetchParams);
 
   private baseApiParams: RequestParams = {
-    credentials: 'same-origin',
+    credentials: "same-origin",
     headers: {},
-    redirect: 'follow',
-    referrerPolicy: 'no-referrer',
+    redirect: "follow",
+    referrerPolicy: "no-referrer",
   };
 
   constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
@@ -82,7 +87,7 @@ export class HttpClient<SecurityDataType = unknown> {
 
   protected encodeQueryParam(key: string, value: any) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === 'number' ? value : `${value}`)}`;
+    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {
@@ -91,37 +96,41 @@ export class HttpClient<SecurityDataType = unknown> {
 
   protected addArrayQueryParam(query: QueryParamsType, key: string) {
     const value = query[key];
-    return value.map((v: any) => this.encodeQueryParam(key, v)).join('&');
+    return value.map((v: any) => this.encodeQueryParam(key, v)).join("&");
   }
 
   protected toQueryString(rawQuery?: QueryParamsType): string {
     const query = rawQuery || {};
-    const keys = Object.keys(query).filter(key => 'undefined' !== typeof query[key]);
+    const keys = Object.keys(query).filter(
+      (key) => "undefined" !== typeof query[key],
+    );
     return keys
-      .map(key =>
+      .map((key) =>
         Array.isArray(query[key])
           ? this.addArrayQueryParam(query, key)
-          : this.addQueryParam(query, key)
+          : this.addQueryParam(query, key),
       )
-      .join('&');
+      .join("&");
   }
 
   protected addQueryParams(rawQuery?: QueryParamsType): string {
     const queryString = this.toQueryString(rawQuery);
-    return queryString ? `?${queryString}` : '';
+    return queryString ? `?${queryString}` : "";
   }
 
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
-      input !== null && (typeof input === 'object' || typeof input === 'string')
+      input !== null && (typeof input === "object" || typeof input === "string")
         ? JSON.stringify(input)
         : input,
     [ContentType.JsonApi]: (input: any) =>
-      input !== null && (typeof input === 'object' || typeof input === 'string')
+      input !== null && (typeof input === "object" || typeof input === "string")
         ? JSON.stringify(input)
         : input,
     [ContentType.Text]: (input: any) =>
-      input !== null && typeof input !== 'string' ? JSON.stringify(input) : input,
+      input !== null && typeof input !== "string"
+        ? JSON.stringify(input)
+        : input,
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
@@ -129,16 +138,19 @@ export class HttpClient<SecurityDataType = unknown> {
           key,
           property instanceof Blob
             ? property
-            : typeof property === 'object' && property !== null
+            : typeof property === "object" && property !== null
               ? JSON.stringify(property)
-              : `${property}`
+              : `${property}`,
         );
         return formData;
       }, new FormData()),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),
   };
 
-  protected mergeRequestParams(params1: RequestParams, params2?: RequestParams): RequestParams {
+  protected mergeRequestParams(
+    params1: RequestParams,
+    params2?: RequestParams,
+  ): RequestParams {
     return {
       ...this.baseApiParams,
       ...params1,
@@ -151,7 +163,9 @@ export class HttpClient<SecurityDataType = unknown> {
     };
   }
 
-  protected createAbortSignal = (cancelToken: CancelToken): AbortSignal | undefined => {
+  protected createAbortSignal = (
+    cancelToken: CancelToken,
+  ): AbortSignal | undefined => {
     if (this.abortControllers.has(cancelToken)) {
       const abortController = this.abortControllers.get(cancelToken);
       if (abortController) {
@@ -186,7 +200,7 @@ export class HttpClient<SecurityDataType = unknown> {
     ...params
   }: FullRequestParams): Promise<HttpResponse<T, E>> => {
     const secureParams =
-      ((typeof secure === 'boolean' ? secure : this.baseApiParams.secure) &&
+      ((typeof secure === "boolean" ? secure : this.baseApiParams.secure) &&
         this.securityWorker &&
         (await this.securityWorker(this.securityData))) ||
       {};
@@ -196,17 +210,25 @@ export class HttpClient<SecurityDataType = unknown> {
     const responseFormat = format || requestParams.format;
 
     return this.customFetch(
-      `${baseUrl || this.baseUrl || ''}${path}${queryString ? `?${queryString}` : ''}`,
+      `${baseUrl || this.baseUrl || ""}${path}${queryString ? `?${queryString}` : ""}`,
       {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
-          ...(type && type !== ContentType.FormData ? { 'Content-Type': type } : {}),
+          ...(type && type !== ContentType.FormData
+            ? { "Content-Type": type }
+            : {}),
         },
-        signal: (cancelToken ? this.createAbortSignal(cancelToken) : requestParams.signal) || null,
-        body: typeof body === 'undefined' || body === null ? null : payloadFormatter(body),
-      }
-    ).then(async response => {
+        signal:
+          (cancelToken
+            ? this.createAbortSignal(cancelToken)
+            : requestParams.signal) || null,
+        body:
+          typeof body === "undefined" || body === null
+            ? null
+            : payloadFormatter(body),
+      },
+    ).then(async (response) => {
       const r = response.clone() as HttpResponse<T, E>;
       r.data = null as unknown as T;
       r.error = null as unknown as E;
@@ -214,7 +236,7 @@ export class HttpClient<SecurityDataType = unknown> {
       const data = !responseFormat
         ? r
         : await response[responseFormat]()
-            .then(data => {
+            .then((data) => {
               if (r.ok) {
                 r.data = data;
               } else {
@@ -222,7 +244,7 @@ export class HttpClient<SecurityDataType = unknown> {
               }
               return r;
             })
-            .catch(e => {
+            .catch((e) => {
               r.error = e;
               return r;
             });
@@ -242,8 +264,43 @@ export class HttpClient<SecurityDataType = unknown> {
  * @version v1
  * @baseUrl http://{defaultHost}
  */
-export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDataType> {
+export class Api<
+  SecurityDataType extends unknown,
+> extends HttpClient<SecurityDataType> {
   api = {
+    /**
+     * No description
+     *
+     * @tags PasswordResets
+     * @name V1PasswordResetRequestCreate
+     * @summary パスワード変更メール
+     * @request POST:/api/v1/password/reset/request
+     */
+    v1PasswordResetRequestCreate: (
+      data: {
+        /**
+         * @format email
+         * @example "user@example.com"
+         */
+        email: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        {
+          /** @example "ご入力のメールアドレス宛に、パスワード再設定用のリンクを送信しました。" */
+          message: string;
+        },
+        any
+      >({
+        path: `/api/v1/password/reset/request`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
     /**
      * No description
      *
@@ -254,16 +311,18 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      */
     v1UserCreate: (
       data: {
-        /** @example "test@example.com" */
-        email: string;
-        /** @example "password123" */
-        password: string;
-        /** @example "password123" */
-        password_confirmation: string;
-        /** @example "test" */
-        name: string;
+        user: {
+          /** @example "test@example.com" */
+          email: string;
+          /** @example "password123" */
+          password: string;
+          /** @example "password123" */
+          password_confirmation: string;
+          /** @example "test" */
+          name: string;
+        };
       },
-      params: RequestParams = {}
+      params: RequestParams = {},
     ) =>
       this.request<
         {
@@ -289,10 +348,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         }
       >({
         path: `/api/v1/user`,
-        method: 'POST',
-        body: { user: data },
+        method: "POST",
+        body: data,
         type: ContentType.Json,
-        format: 'json',
+        format: "json",
         ...params,
       }),
 
@@ -304,15 +363,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @summary ユーザーのログイン
      * @request POST:/api/v1/login
      */
-    v1LoginCreate: (
-      data: {
-        /** @example "test@example.com" */
-        email: string;
-        /** @example "password123" */
-        password: string;
-      },
-      params: RequestParams = {}
-    ) =>
+    v1LoginCreate: (params: RequestParams = {}) =>
       this.request<
         {
           /** @example 200 */
@@ -336,10 +387,8 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         }
       >({
         path: `/api/v1/login`,
-        method: 'POST',
-        body: { user: data },
-        type: ContentType.Json,
-        format: 'json',
+        method: "POST",
+        format: "json",
         ...params,
       }),
 
@@ -362,8 +411,8 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         void
       >({
         path: `/api/v1/logout`,
-        method: 'DELETE',
-        format: 'json',
+        method: "DELETE",
+        format: "json",
         ...params,
       }),
   };

--- a/frontend/src/types/generated/Api.ts
+++ b/frontend/src/types/generated/Api.ts
@@ -311,16 +311,14 @@ export class Api<
      */
     v1UserCreate: (
       data: {
-        user: {
-          /** @example "test@example.com" */
-          email: string;
-          /** @example "password123" */
-          password: string;
-          /** @example "password123" */
-          password_confirmation: string;
-          /** @example "test" */
-          name: string;
-        };
+        /** @example "test@example.com" */
+        email: string;
+        /** @example "password123" */
+        password: string;
+        /** @example "password123" */
+        password_confirmation: string;
+        /** @example "test" */
+        name: string;
       },
       params: RequestParams = {},
     ) =>
@@ -349,7 +347,7 @@ export class Api<
       >({
         path: `/api/v1/user`,
         method: "POST",
-        body: data,
+        body: { user: data },
         type: ContentType.Json,
         format: "json",
         ...params,
@@ -363,7 +361,15 @@ export class Api<
      * @summary ユーザーのログイン
      * @request POST:/api/v1/login
      */
-    v1LoginCreate: (params: RequestParams = {}) =>
+    v1LoginCreate: (
+      data: {
+        /** @example "test@example.com" */
+        email: string;
+        /** @example "password123" */
+        password: string;
+      },
+      params: RequestParams = {},
+    ) =>
       this.request<
         {
           /** @example 200 */
@@ -388,6 +394,8 @@ export class Api<
       >({
         path: `/api/v1/login`,
         method: "POST",
+        body: { user: data },
+        type: ContentType.Json,
         format: "json",
         ...params,
       }),

--- a/rails/app/controllers/api/v1/password_resets_controller.rb
+++ b/rails/app/controllers/api/v1/password_resets_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::PasswordResetsController < ApplicationController
+  def create
+    user = User.find_by(email: params[:email])
+
+    if user
+      token = user.send(:set_reset_password_token)
+      UserMailer.reset_password(user, token).deliver_later
+    end
+
+    render json: { message: "ご入力のメールアドレス宛に、パスワード再設定用のリンクを送信しました。" }, status: :ok
+  end
+end

--- a/rails/app/mailers/user_mailer.rb
+++ b/rails/app/mailers/user_mailer.rb
@@ -1,5 +1,4 @@
 class UserMailer < ApplicationMailer
-
   # Subject can be set in your I18n file at config/locales/en.yml
   # with the following lookup:
   #

--- a/rails/app/mailers/user_mailer.rb
+++ b/rails/app/mailers/user_mailer.rb
@@ -9,6 +9,6 @@ class UserMailer < ApplicationMailer
     @token = token
     url = "#{ENV["FRONTEND_URL"]}/password/reset/#{@token}?email=#{@user.email}"
 
-    mail(to: @user.email, subject: "パスワードリセットのご案内", body: "パスワードリセットはこちらのリンクからお願いします： #{url}")
+    mail(to: @user.email, subject: "パスワード再設定のご案内", body: "パスワード再設定はこちらのリンクからお願いします： #{url}")
   end
 end

--- a/rails/app/mailers/user_mailer.rb
+++ b/rails/app/mailers/user_mailer.rb
@@ -1,0 +1,15 @@
+class UserMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.reset_password_email.subject
+  #
+  def reset_password(user, token)
+    @user = user
+    @token = token
+    url = "#{ENV["FRONTEND_URL"]}/password/reset/#{@token}?email=#{@user.email}"
+
+    mail(to: @user.email, subject: "パスワードリセットのご案内", body: "パスワードリセットはこちらのリンクからお願いします： #{url}")
+  end
+end

--- a/rails/config/environments/development.rb
+++ b/rails/config/environments/development.rb
@@ -70,11 +70,11 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address: "smtp.gmail.com",
-    domain: "gmail.com",
-    port: 587,
-    user_name: ENV["GMAIL_EMAIL"],
-    password: ENV["GMAIL_APP_PASSWORD"],
+    address: "sandbox.smtp.mailtrap.io",
+    domain: "sandbox.smtp.mailtrap.io",
+    port: 2525,
+    user_name: ENV["MAILTRAP_USERNAME"],
+    password: ENV["MAILTRAP_PASSWORD"],
     authentication: "plain",
     enable_starttles: true,
    }

--- a/rails/config/environments/development.rb
+++ b/rails/config/environments/development.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
 
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
-
+  config.active_job.queue_adapter = :async
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
@@ -68,4 +68,14 @@ Rails.application.configure do
 
   config.action_mailer.default_options = { from: "no-replay@example.com" }
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    domain: "gmail.com",
+    port: 587,
+    user_name: ENV["GMAIL_EMAIL"],
+    password: ENV["GMAIL_APP_PASSWORD"],
+    authentication: "plain",
+    enable_starttles: true,
+   }
 end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -33,6 +33,8 @@ Rails.application.routes.draw do
       #   resources :knowledges, only: [:index, :create, :update, :destroy]
       # end
       resources :chats, only: [:create]
+
+      post "password/reset/request", to: "password_resets#create"
     end
   end
   mount Rswag::Ui::Engine => '/api-docs'

--- a/rails/spec/integration/api/v1/password_resets_spec.rb
+++ b/rails/spec/integration/api/v1/password_resets_spec.rb
@@ -1,0 +1,43 @@
+require 'swagger_helper'
+
+RSpec.describe 'Api::V1::PasswordResets', type: :request, swagger_doc: 'v1/swagger.yaml' do
+  path '/api/v1/password/reset/request' do
+    post 'パスワード変更メール' do
+      tags 'PasswordResets'
+      consumes 'application/json'
+      produces 'application/json'
+      parameter name: :payload, in: :body, schema: {
+        type: :object,
+        required: ['email'],
+        properties: {
+          email: { type: :string, format: :email, example: 'user@example.com' }
+        }
+      }
+
+      response '200', 'リセットメール送信成功' do
+        schema type: :object, properties: {
+          message: { type: :string, example: 'ご入力のメールアドレス宛に、パスワード再設定用のリンクを送信しました。' }
+        },
+        required: ['message']
+        let(:user) { create(:user, email: 'user@example.com') }
+        let(:payload) { { email: user.email } }
+
+        examples = {
+          success: {
+            summary: 'メールアドレスが存在する場合',
+            value: { message: 'ご入力のメールアドレス宛に、パスワード再設定用のリンクを送信しました。' }
+          },
+          failure: {
+            summary: 'メールアドレスが存在しない場合（セキュリティのため成功扱い）',
+            value: { message: 'ご入力のメールアドレス宛に、パスワード再設定用のリンクを送信しました。' }
+          }
+        }
+
+        run_test! do |response|
+          body = JSON.parse(response.body)
+          expect(body['message']).to eq('ご入力のメールアドレス宛に、パスワード再設定用のリンクを送信しました。')
+        end
+      end
+    end
+  end
+end

--- a/rails/swagger/v1/swagger.yaml
+++ b/rails/swagger/v1/swagger.yaml
@@ -10,6 +10,37 @@ components:
       scheme: bearer
       bearerFormat: JWT
 paths:
+  "/api/v1/password/reset/request":
+    post:
+      summary: パスワード変更メール
+      tags:
+      - PasswordResets
+      parameters: []
+      responses:
+        '200':
+          description: リセットメール送信成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: ご入力のメールアドレス宛に、パスワード再設定用のリンクを送信しました。
+                required:
+                - message
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - email
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: user@example.com
   "/api/v1/user":
     post:
       summary: ユーザーのサインアップ
@@ -140,24 +171,6 @@ paths:
                   message:
                     type: string
                     example: メールアドレスか、パスワードが不正です
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                user:
-                  type: object
-                  required:
-                  - email
-                  - password
-                  properties:
-                    email:
-                      type: string
-                      example: test@example.com
-                    password:
-                      type: string
-                      example: password123
   "/api/v1/logout":
     delete:
       summary: ユーザーのログアウト


### PR DESCRIPTION
## 概要
https://www.notion.so/21e2946467fd80bc8cf8e461efbf2268?v=21e2946467fd80138aed000c282b35d0&p=2692946467fd802b8870f11e97491a6f&pm=s
<!--
NotionのURLを書きましょう
背景があればそれも併せて書きましょう
-->

## 詳細
- パスワード変更のためのメール送信機能実装

<!--
レビュアーに重点的に見て欲しい内容を書きましょう  
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです  
-->

## 動作確認
### MailTrap
<img width="1440" height="900" alt="スクリーンショット 2025-09-13 14 58 22" src="https://github.com/user-attachments/assets/e311dc56-ff0a-4914-8cc2-ace33974baae" />

### Postman
<img width="1440" height="900" alt="スクリーンショット 2025-09-13 15 17 54" src="https://github.com/user-attachments/assets/73d775ff-047f-4a37-bafe-08b3ba4f3ba7" />



<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう  
-->

## その他

<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください  
-->
- PostMan
- Mailtrap

## 参考情報

<!--
参考記事の url などを記載しましょう  
-->
